### PR TITLE
Add new testes based on a modified library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ compiler:
   - gcc
 
 env:
-  - VER_NEWRELIC_C_SDK=1.3.0
+  - VER_NEWRELIC_C_SDK=1.3.0 VER_OPENRESTY=1.19.9.1
 
 addons:
   apt:
@@ -27,8 +27,8 @@ before_install:
 
 install:
   - mkdir ./vendor && cd ./vendor
-  - wget http://openresty.org/download/openresty-1.19.9.1.tar.gz && tar -xf openresty-1.19.9.1.tar.gz
-  - cd openresty-1.19.9.1/
+  - wget http://openresty.org/download/openresty-${VER_OPENRESTY}.tar.gz && tar -xf openresty-${VER_OPENRESTY}.tar.gz
+  - cd openresty-${VER_OPENRESTY}/
   - ./configure --prefix=/opt/openresty && make && sudo make install && cd ..
   - export PATH=/opt/openresty/nginx/sbin:$PATH
   - wget https://github.com/newrelic/c-sdk/archive/refs/tags/v${VER_NEWRELIC_C_SDK}.tar.gz && tar -xf "v${VER_NEWRELIC_C_SDK}.tar.gz"
@@ -39,12 +39,11 @@ install:
   - sudo mkdir -p /usr/local/lib && sudo cp libnewrelic.so /usr/local/lib/
   - sudo ldconfig
   - cd ../../
-  - luarocks --local install luacheck
-  - luarocks --local install lua-cjson
-  - luarocks --local install luaposix
-  - luarocks --local install luasocket
-  - luarocks --local install luasec
-  - luarocks --local install https://raw.githubusercontent.com/jdesgats/telescope/master/rockspecs/telescope-scm-1.rockspec
+  - mkdir -p util/include/axiom
+  - cp vendor/c-sdk-${VER_NEWRELIC_C_SDK}/include/* util/include/
+  - cp vendor/c-sdk-${VER_NEWRELIC_C_SDK}/vendor/newrelic/axiom/*.h util/include/axiom/
+  - cd util && make && sudo cp libnewrelic.so /usr/local/lib/libnewrelic.so && cd ../
+  - sudo ldconfig
   - sudo npm install typescript -g
   - export PERL_MM_USE_DEFAULT=1
   - sudo cpan Test::Nginx

--- a/lib/lua-nri/newrelic.lua
+++ b/lib/lua-nri/newrelic.lua
@@ -970,7 +970,7 @@ ffi.cdef([[
 
 -- local c-sdk lib https://github.com/newrelic/c-sdk/releases/tag/v1.3.0
 -- $ ar -x libnewrelic.a
--- $ gcc -shared -lnewrelic -lpcre -lm -lpthread -rdynamic *.o -o libnewrelic.so
+-- $ gcc -shared -lpcre -lm -lpthread -rdynamic *.o -o libnewrelic.so
 local nr = ffi.load('libnewrelic', true)
 
 -- configure log
@@ -1179,7 +1179,7 @@ local newrelic_start_datastore_segment = function(
   collection,
   operation,
   host,
-  port_or_path_id,
+  port_path_or_id,
   database_name,
   query)
   local params = ffi.new("newrelic_datastore_segment_params_t", {
@@ -1187,7 +1187,7 @@ local newrelic_start_datastore_segment = function(
     collection = collection,
     operation = operation,
     host = host,
-    port_or_path_id = port_or_path_id,
+    port_path_or_id = port_path_or_id,
     database_name = database_name,
     query = query
   })

--- a/lib/lua-nri/newrelic_agent.lua
+++ b/lib/lua-nri/newrelic_agent.lua
@@ -89,7 +89,7 @@ end
 
 _M.ignore_transaction = function()
   local transaction_id = ngx.ctx.nr_transaction_id
-  if _M.ensabled and transaction_id then
+  if _M.enabled and transaction_id then
     return newrelic.ignore_transaction(transaction_id)
   end
 end
@@ -135,7 +135,7 @@ _M.record_custom_metric = function(name, milliseconds)
   end
 end
 
-_M.start_datastore_segment = function(product, collection, operation, host, port_or_path_id, database_name, query)
+_M.start_datastore_segment = function(product, collection, operation, host, port_path_or_id, database_name, query)
   local transaction_id = ngx.ctx.nr_transaction_id
   if _M.enabled and transaction_id then
     return newrelic.start_datastore_segment(
@@ -144,7 +144,7 @@ _M.start_datastore_segment = function(product, collection, operation, host, port
       collection,
       operation,
       host,
-      port_or_path_id,
+      port_path_or_id,
       database_name,
       query)
   end

--- a/t/02-transaction.t
+++ b/t/02-transaction.t
@@ -1,0 +1,248 @@
+# vim:set ft= ts=4 sw=4 et:
+
+use Test::Nginx::Socket;
+use Cwd qw(cwd);
+
+plan tests => repeat_each() * (blocks() * 3);
+
+my $pwd = cwd();
+
+our $MainConfigWithoutNrConfig = qq{
+    # env NEWRELIC_APP_LICENSE_KEY;
+    # env NEWRELIC_APP_NAME;
+};
+
+our $MainConfig = qq{
+    env NEWRELIC_APP_LICENSE_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    env NEWRELIC_APP_NAME=test-app;
+};
+
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    init_worker_by_lua_block {
+        local newrelic_agent = require("lua-nri.newrelic_agent")
+        configuration = {
+            log = {
+                enabled = true,
+                filename = "t/servroot/logs/error.log",
+                level = newrelic_agent.consts.NEWRELIC_LOG_DEBUG,
+            }
+        }
+        newrelic_agent.enable(configuration)
+    }
+
+    error_log logs/error.log debug;
+};
+
+$ENV{TEST_NGINX_RESOLVER} = '8.8.8.8';
+
+no_long_string();
+#no_diff();
+
+run_tests();
+
+__DATA__
+=== TEST 1: Start web transaction.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        echo "OK";
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_start_web_transaction' no errors | name: /a
+
+=== TEST 2: End transaction.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        echo "OK";
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_end_transaction' no errors
+
+=== TEST 3: Transaction Attributes Int.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+            newrelic_agent.add_attribute("IntKey", 1)
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_add_attribute_int' no erros | key: IntKey, value: 1
+
+=== TEST 4: Transaction Attributes Long.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+            newrelic_agent.add_attribute("LongKey", 2147483649)
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_add_attribute_long' no erros | key: LongKey, value: 2147483649
+
+=== TEST 5: Transaction Attributes Double.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+            newrelic_agent.add_attribute("DoubleKey", 1.1)
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_add_attribute_double' no erros | key: DoubleKey, value: 1.1
+
+=== TEST 6: Transaction Attributes String.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+            newrelic_agent.add_attribute("StringKey", "StringValue")
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_add_attribute_string' no erros | key: StringKey, value: StringValue
+
+=== TEST 7: Start non web transaction.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_non_web_transaction("/a-non-web")';
+        echo "OK";
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_start_non_web_transaction' no errors | name: /a-non-web
+
+=== TEST 8: End transaction.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_non_web_transaction("/a-non-web")';
+        echo "OK";
+        log_by_lua 'require("lua-nri.newrelic_agent").end_non_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_end_transaction' no errors
+
+=== TEST 9: Ignore transaction.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction("/a-non-web")';
+        content_by_lua_block {
+            newrelic_agent = require('lua-nri.newrelic_agent')
+            newrelic_agent.ignore_transaction()
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_ignore_transaction' no errors
+
+=== TEST 10: Set transaction name.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction("/a-non-web")';
+        content_by_lua_block {
+            newrelic_agent = require('lua-nri.newrelic_agent')
+            newrelic_agent.set_transaction_name("CustomName")
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_set_transaction_name' no errors | name: CustomName
+
+=== TEST 11: Set transaction timing.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction("/a-non-web")';
+        content_by_lua_block {
+            newrelic_agent = require('lua-nri.newrelic_agent')
+            newrelic_agent.set_transaction_timing(100, 0)
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_set_transaction_timing' no errors | start_time: 0, duration: 100

--- a/t/03-customevent.t
+++ b/t/03-customevent.t
@@ -1,0 +1,199 @@
+# vim:set ft= ts=4 sw=4 et:
+
+use Test::Nginx::Socket;
+use Cwd qw(cwd);
+
+plan tests => repeat_each() * (blocks() * 3);
+
+my $pwd = cwd();
+
+our $MainConfigWithoutNrConfig = qq{
+    # env NEWRELIC_APP_LICENSE_KEY;
+    # env NEWRELIC_APP_NAME;
+};
+
+our $MainConfig = qq{
+    env NEWRELIC_APP_LICENSE_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    env NEWRELIC_APP_NAME=test-app;
+};
+
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    init_worker_by_lua_block {
+        local newrelic_agent = require("lua-nri.newrelic_agent")
+        configuration = {
+            log = {
+                enabled = true,
+                filename = "t/servroot/logs/error.log",
+                level = newrelic_agent.consts.NEWRELIC_LOG_DEBUG,
+            }
+        }
+        newrelic_agent.enable(configuration)
+    }
+
+    error_log logs/error.log debug;
+};
+
+$ENV{TEST_NGINX_RESOLVER} = '8.8.8.8';
+
+no_long_string();
+#no_diff();
+
+run_tests();
+
+__DATA__
+=== TEST 1: Create custom event.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+            newrelic_agent.custom_event("CustomEvent")
+
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_create_custom_event' no errors | event_type: CustomEvent
+
+=== TEST 2: Record custom event.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+            local custom_event = newrelic_agent.custom_event("CustomEvent")
+
+            newrelic_agent.record_custom_event(custom_event)
+
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_record_custom_event' no errors
+
+=== TEST 3: Discard custom event.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+            local custom_event = newrelic_agent.custom_event("CustomEvent")
+
+            newrelic_agent.discard_custom_event(custom_event)
+
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_discard_custom_event' no errors
+
+=== TEST 4: Add attribute to custom event Int.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+            local custom_event = newrelic_agent.custom_event("CustomEvent")
+
+            newrelic_agent.custom_event_add_attribute(custom_event, "IntKey", 1)
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_custom_event_add_attribute_int' no errors | key: IntKey, value: 1
+
+=== TEST 5: Add attribute to custom event Long.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+            local custom_event = newrelic_agent.custom_event("CustomEvent")
+
+            newrelic_agent.custom_event_add_attribute(custom_event, "LongKey", 21474836491)
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_custom_event_add_attribute_long' no errors | key: LongKey, value: 2147483649
+
+=== TEST 6: Add attribute to custom event Double.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+            local custom_event = newrelic_agent.custom_event("CustomEvent")
+
+            newrelic_agent.custom_event_add_attribute(custom_event, "DoubleKey", 1.1)
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_custom_event_add_attribute_double' no errors | key: DoubleKey, value: 1.1
+
+=== TEST 7: Add attribute to custom event String.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+            local custom_event = newrelic_agent.custom_event("CustomEvent")
+
+            newrelic_agent.custom_event_add_attribute(custom_event, "StringKey", "StringValue")
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_custom_event_add_attribute_string' no errors | key: StringKey, value: StringValue

--- a/t/04-custommetric.t
+++ b/t/04-custommetric.t
@@ -43,39 +43,7 @@ no_long_string();
 run_tests();
 
 __DATA__
-=== TEST 1: Not configured agent.
---- main_config eval: $::MainConfigWithoutNrConfig
---- http_config eval: $::HttpConfig
---- config
-    location = /a {
-        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
-        echo "OK";
-        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
-    }
---- request
-GET /a
---- response_body
-OK
---- error_log
-Newrelic Lua Agent is not configured for
-
-=== TEST 2: Configured agent.
---- main_config eval: $::MainConfig
---- http_config eval: $::HttpConfig
---- config
-    location = /a {
-        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
-        echo "OK";
-        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
-    }
---- request
-GET /a
---- response_body
-OK
---- error_log
-Starting Newrelic Lua Agent for
-
-=== TEST 3: Notice Error.
+=== TEST 1: Create custom event.
 --- main_config eval: $::MainConfig
 --- http_config eval: $::HttpConfig
 --- config
@@ -83,7 +51,7 @@ Starting Newrelic Lua Agent for
         access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
         content_by_lua_block {
             local newrelic_agent = require("lua-nri.newrelic_agent")
-            newrelic_agent.notice_error(100, "Message", "Class")
+            newrelic_agent.record_custom_metric("CustomMetric", 100)
             ngx.say("OK")
         }
         log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
@@ -93,4 +61,4 @@ GET /a
 --- response_body
 OK
 --- shutdown_error_log
-DEBUG 'newrelic_notice_error' no errors | priority: 100, errmsg: Message, errclass: Class
+DEBUG 'newrelic_record_custom_metric' no errors | metric_name: CustomMetric, milliseconds: 100.0

--- a/t/05-segments.t
+++ b/t/05-segments.t
@@ -1,0 +1,199 @@
+# vim:set ft= ts=4 sw=4 et:
+
+use Test::Nginx::Socket;
+use Cwd qw(cwd);
+
+plan tests => repeat_each() * (blocks() * 3);
+
+my $pwd = cwd();
+
+our $MainConfigWithoutNrConfig = qq{
+    # env NEWRELIC_APP_LICENSE_KEY;
+    # env NEWRELIC_APP_NAME;
+};
+
+our $MainConfig = qq{
+    env NEWRELIC_APP_LICENSE_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    env NEWRELIC_APP_NAME=test-app;
+};
+
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    init_worker_by_lua_block {
+        local newrelic_agent = require("lua-nri.newrelic_agent")
+        configuration = {
+            log = {
+                enabled = true,
+                filename = "t/servroot/logs/error.log",
+                level = newrelic_agent.consts.NEWRELIC_LOG_DEBUG,
+            }
+        }
+        newrelic_agent.enable(configuration)
+    }
+
+    error_log logs/error.log debug;
+};
+
+$ENV{TEST_NGINX_RESOLVER} = '8.8.8.8';
+
+no_long_string();
+#no_diff();
+
+run_tests();
+
+__DATA__
+=== TEST 1: Start Segment.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+
+            newrelic_agent.start_segment("CustomSegment", "CustomCategory")
+
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_start_segment' no errors | name: CustomSegment, category: CustomCategory
+
+=== TEST 2: Start datastore Segment.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+
+            newrelic_agent.start_datastore_segment(newrelic_agent.consts.NEWRELIC_DATASTORE_MYSQL, "Collection", "SELECT", "localhost", "3036", "users", "SELECT * FROM users")
+
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_start_datastore_segment' no errors | product: MYSQL, collection: Collection, operation: SELECT, host: localhost, port: 3036, database_name: users, query: SELECT * FROM users
+
+=== TEST 3: Start external Segment.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+
+            newrelic_agent.start_external_segment("Uri", "Procedure", "Library")
+
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_start_external_segment' no errors | uri: Uri, procedure: Procedure, library: Library
+
+=== TEST 4: End Segment.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+
+            local segment = newrelic_agent.start_external_segment("Uri", "Procedure", "Library")
+            newrelic_agent.end_segment(segment)
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_end_segment' no errors
+
+=== TEST 5: Set segment timing.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+
+            local segment = newrelic_agent.start_external_segment("Uri", "Procedure", "Library")
+            newrelic_agent.set_segment_timing(segment, 100, 0)
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_set_segment_timing' no errors | start_time: 0, duration: 100
+
+=== TEST 6: Set segment parent root.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+
+            local segment = newrelic_agent.start_external_segment("Uri", "Procedure", "Library")
+            newrelic_agent.set_segment_parent_root(segment)
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_set_segment_parent_root' no errors
+
+=== TEST 7: Set segment parent.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+
+            local parent = newrelic_agent.start_segment("CustomSegment", "CustomCategory")
+            local segment = newrelic_agent.start_external_segment("Uri", "Procedure", "Library")
+            newrelic_agent.set_segment_parent(segment, parent)
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_set_segment_parent' no errors

--- a/t/06-trace.t
+++ b/t/06-trace.t
@@ -1,0 +1,134 @@
+# vim:set ft= ts=4 sw=4 et:
+
+use Test::Nginx::Socket;
+use Cwd qw(cwd);
+
+plan tests => repeat_each() * (blocks() * 3);
+
+my $pwd = cwd();
+
+our $MainConfigWithoutNrConfig = qq{
+    # env NEWRELIC_APP_LICENSE_KEY;
+    # env NEWRELIC_APP_NAME;
+};
+
+our $MainConfig = qq{
+    env NEWRELIC_APP_LICENSE_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+    env NEWRELIC_APP_NAME=test-app;
+};
+
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    init_worker_by_lua_block {
+        local newrelic_agent = require("lua-nri.newrelic_agent")
+        configuration = {
+            log = {
+                enabled = true,
+                filename = "t/servroot/logs/error.log",
+                level = newrelic_agent.consts.NEWRELIC_LOG_DEBUG,
+            }
+        }
+        newrelic_agent.enable(configuration)
+    }
+
+    error_log logs/error.log debug;
+};
+
+$ENV{TEST_NGINX_RESOLVER} = '8.8.8.8';
+
+no_long_string();
+#no_diff();
+
+run_tests();
+
+__DATA__
+=== TEST 1: Create Distributed Trace Payload Segment.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+
+            local segment = newrelic_agent.start_segment("CustomSegment", "CustomCategory")
+            newrelic_agent.create_distributed_trace_payload(segment)
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_create_distributed_trace_payload' no errors
+
+=== TEST 2: Create Distributed Trace Payload HTTPSafe Segment.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+
+            local segment = newrelic_agent.start_segment("CustomSegment", "CustomCategory")
+            newrelic_agent.create_distributed_trace_payload_httpsafe(segment)
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_create_distributed_trace_payload_httpsafe' no errors
+
+=== TEST 3: Accept Distributed Trace Payload Segment.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+
+            local segment = newrelic_agent.start_segment("CustomSegment", "CustomCategory")
+            newrelic_agent.create_distributed_trace_payload(segment)
+            newrelic_agent.accept_distributed_trace_payload("Payload", newrelic_agent.consts.NEWRELIC_TRANSPORT_TYPE_KAFKA)
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_accept_distributed_trace_payload' no errors | payload: Payload, transport_type: Kafka
+
+=== TEST 3: Accept Distributed Trace Payload Segment.
+--- main_config eval: $::MainConfig
+--- http_config eval: $::HttpConfig
+--- config
+    location = /a {
+        access_by_lua 'require("lua-nri.newrelic_agent").start_web_transaction()';
+        content_by_lua_block {
+            local newrelic_agent = require("lua-nri.newrelic_agent")
+
+            local segment = newrelic_agent.start_segment("CustomSegment", "CustomCategory")
+            newrelic_agent.create_distributed_trace_payload_httpsafe(segment)
+            newrelic_agent.accept_distributed_trace_payload_httpsafe("Payload64", newrelic_agent.consts.NEWRELIC_TRANSPORT_TYPE_KAFKA)
+            ngx.say("OK")
+        }
+        log_by_lua 'require("lua-nri.newrelic_agent").end_web_transaction()';
+    }
+--- request
+GET /a
+--- response_body
+OK
+--- shutdown_error_log
+DEBUG 'newrelic_accept_distributed_trace_payload_httpsafe' no errors | payload: Payload64, transport_type: Kafka

--- a/util/Makefile
+++ b/util/Makefile
@@ -1,0 +1,6 @@
+all:
+	gcc -Wall -fPIC -I./include -I./include/axiom -o libnewrelic.o -c libnewrelic.c
+	ld -shared -o libnewrelic.so libnewrelic.o
+
+#client:
+#	gcc  client.c -fPIC -Wall -Wl,-rpath=. -I./include -L. -lnewrelic -o client

--- a/util/client.c
+++ b/util/client.c
@@ -1,0 +1,166 @@
+#include <libnewrelic.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main() {
+    newrelic_configure_log("filename", NEWRELIC_LOG_DEBUG);
+
+    newrelic_init("", -1);
+    newrelic_init("socket", 1);
+
+    newrelic_create_app_config(NULL, NULL);
+    newrelic_create_app_config("App Name", "");
+    newrelic_create_app_config("App Name", "License Key");
+
+    newrelic_destroy_app_config(NULL);
+    newrelic_destroy_app_config(get_app_config_pointer());
+
+    newrelic_create_app(NULL, 0);
+    newrelic_create_app(get_app_config_pointer(), 0);
+
+    newrelic_start_web_transaction(NULL, "");
+    newrelic_start_web_transaction(get_app_pointer(), "");
+    newrelic_start_web_transaction(get_app_pointer(), "Name");
+
+    newrelic_start_non_web_transaction(NULL, "");
+    newrelic_start_non_web_transaction(get_app_pointer(), "");
+    newrelic_start_non_web_transaction(get_app_pointer(), "Name");
+
+    newrelic_set_transaction_timing(NULL, 0, 0);
+    newrelic_set_transaction_timing(get_transaction_pointer(), 0, 0);
+
+    newrelic_add_attribute_int(NULL, "", 0);
+    newrelic_add_attribute_int(get_transaction_pointer(), "", 0);
+    newrelic_add_attribute_int(get_transaction_pointer(), "Key", 1);
+
+    newrelic_add_attribute_long(NULL, "", 0);
+    newrelic_add_attribute_long(get_transaction_pointer(), "", 0);
+    newrelic_add_attribute_long(get_transaction_pointer(), "Key", 10);
+
+    newrelic_add_attribute_double(NULL, "", 0);
+    newrelic_add_attribute_double(get_transaction_pointer(), "", 0);
+    newrelic_add_attribute_double(get_transaction_pointer(), "Key", 0.1);
+
+    newrelic_add_attribute_string(NULL, "", "");
+    newrelic_add_attribute_string(get_transaction_pointer(), "", "");
+    newrelic_add_attribute_string(get_transaction_pointer(), "Key", "");
+    newrelic_add_attribute_string(get_transaction_pointer(), "Key", "Value");
+
+    newrelic_notice_error(NULL, 0, "", "");
+    newrelic_notice_error(get_transaction_pointer(), 0, "", "");
+    newrelic_notice_error(get_transaction_pointer(), 0, "Error Message", "");
+    newrelic_notice_error(get_transaction_pointer(), 0, "Error Message", "Error Class");
+
+    newrelic_start_segment(NULL, "", "");
+    newrelic_start_segment(get_transaction_pointer(), "", "");
+    newrelic_start_segment(get_transaction_pointer(), "Name", "");
+    newrelic_start_segment(get_transaction_pointer(), "Name", "Category");
+
+    newrelic_start_datastore_segment(NULL, NULL);
+    newrelic_start_datastore_segment(get_transaction_pointer(), NULL);
+
+    newrelic_datastore_segment_params_t datastore_params = {
+        .product = "MySQL",
+        .collection = "Collection",
+        .operation = "SELECT",
+        .host = "localhost",
+        .port_path_or_id = "3036",
+        .database_name = "users",
+        .query = "SELECT * FROM users"
+    };
+    newrelic_start_datastore_segment(get_transaction_pointer(), &datastore_params);
+
+    newrelic_start_external_segment(NULL, NULL);
+    newrelic_start_external_segment(get_transaction_pointer(), NULL);
+
+    newrelic_external_segment_params_t external_params = {
+        .uri = "Uri",
+        .procedure = "Procedure",
+        .library = "Library"
+    };
+
+    newrelic_start_external_segment(get_transaction_pointer(), &external_params);
+
+    newrelic_set_segment_parent(NULL, NULL);
+    newrelic_set_segment_parent(get_segment_pointer(), NULL);
+    newrelic_set_segment_parent(get_segment_pointer(), get_segment_pointer());
+
+    newrelic_set_segment_parent_root(NULL);
+    newrelic_set_segment_parent_root(get_segment_pointer());
+
+    newrelic_set_segment_timing(NULL, 0, 0);
+    newrelic_set_segment_timing(get_segment_pointer(), 1, 1);
+
+    newrelic_end_segment(NULL, NULL);
+    newrelic_end_segment(get_transaction_pointer(), NULL);
+    newrelic_segment_t *end_segment = NULL;
+    newrelic_end_segment(get_transaction_pointer(), &end_segment);
+    newrelic_segment_t *end_segment2= get_segment_pointer();
+    newrelic_end_segment(get_transaction_pointer(), &end_segment2);
+
+    newrelic_create_custom_event("");
+    newrelic_create_custom_event("CustomEventType");
+
+    newrelic_discard_custom_event(NULL);
+    newrelic_custom_event_t *d_event = NULL;
+    newrelic_discard_custom_event(&d_event);
+    newrelic_custom_event_t *d_event2 = get_custom_event();
+    newrelic_discard_custom_event(&d_event2);
+
+    newrelic_record_custom_event(NULL, NULL);
+    newrelic_record_custom_event(get_transaction_pointer(), NULL);
+    newrelic_custom_event_t *r_event = NULL;
+    newrelic_record_custom_event(get_transaction_pointer(), &r_event);
+    newrelic_custom_event_t *r_event2 = get_custom_event();
+    newrelic_record_custom_event(get_transaction_pointer(), &r_event2);
+
+    newrelic_custom_event_add_attribute_int(NULL, "", 0);
+    newrelic_custom_event_add_attribute_int(get_custom_event(), "", 0);
+    newrelic_custom_event_add_attribute_int(get_custom_event(), "Attribute", 1);
+
+    newrelic_custom_event_add_attribute_long(NULL, "", 0);
+    newrelic_custom_event_add_attribute_long(get_custom_event(), "", 0);
+    newrelic_custom_event_add_attribute_long(get_custom_event(), "Attribute", 1);
+
+    newrelic_custom_event_add_attribute_double(NULL, "", 0);
+    newrelic_custom_event_add_attribute_double(get_custom_event(), "", 0);
+    newrelic_custom_event_add_attribute_double(get_custom_event(), "Attribute", 1.1);
+
+    newrelic_custom_event_add_attribute_string(NULL, "", "");
+    newrelic_custom_event_add_attribute_string(get_custom_event(), "", "");
+    newrelic_custom_event_add_attribute_string(get_custom_event(), "Attribute", "");
+    newrelic_custom_event_add_attribute_string(get_custom_event(), "Attribute", "Value");
+
+    newrelic_record_custom_metric(NULL, "", 0);
+    newrelic_record_custom_metric(get_transaction_pointer(), "", 0);
+    newrelic_record_custom_metric(get_transaction_pointer(), "Custom/Metric", 0);
+    newrelic_record_custom_metric(get_transaction_pointer(), "Custom/Metric", -1);
+
+    newrelic_ignore_transaction(NULL);
+    newrelic_ignore_transaction(get_transaction_pointer());
+
+    newrelic_create_distributed_trace_payload(NULL, NULL);
+    newrelic_create_distributed_trace_payload(get_transaction_pointer(), NULL);
+    newrelic_create_distributed_trace_payload(get_transaction_pointer(), get_segment_pointer());
+
+    newrelic_accept_distributed_trace_payload(NULL, "", "");
+    newrelic_accept_distributed_trace_payload(get_transaction_pointer(), "", "");
+    newrelic_accept_distributed_trace_payload(get_transaction_pointer(), "Payload", "");
+    newrelic_accept_distributed_trace_payload(get_transaction_pointer(), "Payload", "Transport Type");
+
+    newrelic_create_distributed_trace_payload_httpsafe(NULL, NULL);
+    newrelic_create_distributed_trace_payload_httpsafe(get_transaction_pointer(), NULL);
+    newrelic_create_distributed_trace_payload_httpsafe(get_transaction_pointer(), get_segment_pointer());
+
+    newrelic_accept_distributed_trace_payload_httpsafe(NULL, "", "");
+    newrelic_accept_distributed_trace_payload_httpsafe(get_transaction_pointer(), "", "");
+    newrelic_accept_distributed_trace_payload_httpsafe(get_transaction_pointer(), "Payload", "");
+    newrelic_accept_distributed_trace_payload_httpsafe(get_transaction_pointer(), "Payload", "Transport Type");
+
+    newrelic_set_transaction_name(NULL, "");
+    newrelic_set_transaction_name(get_transaction_pointer(), "");
+    newrelic_set_transaction_name(get_transaction_pointer(), "Transaction Name");
+    return 0;
+}

--- a/util/libnewrelic.c
+++ b/util/libnewrelic.c
@@ -1,0 +1,628 @@
+#include <libnewrelic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#include <app.h>
+#include <transaction.h>
+#include <segment.h>
+#include <custom_event.h>
+
+/** for debug proposes we want to maintain state */
+char *internal_filename;
+FILE *internal_logfile;
+newrelic_app_config_t *internal_app_config;
+newrelic_app_t *internal_app;
+newrelic_txn_t *web_transaction;
+newrelic_txn_t *non_web_transaction;
+newrelic_segment_t *segment;
+newrelic_custom_event_t *custom_event;
+newrelic_external_segment_params_t *external_segment_params;
+newrelic_datastore_segment_params_t *datastore_segment_params;
+newrelic_loglevel_t internal_loglevel;
+
+newrelic_app_config_t *get_app_config_pointer() {
+    if (internal_app_config != NULL) {
+        return internal_app_config;
+    }
+
+    internal_app_config = (newrelic_app_config_t *) malloc(sizeof(newrelic_app_config_t));
+    return internal_app_config;
+}
+
+newrelic_app_t *get_app_pointer() {
+    if (internal_app != NULL) {
+        return internal_app;
+    }
+
+    internal_app = (newrelic_app_t *) malloc(sizeof(newrelic_app_t));
+    return internal_app;
+}
+
+newrelic_txn_t *get_transaction_pointer() {
+    if (web_transaction != NULL) {
+        return web_transaction;
+    }
+    web_transaction = (newrelic_txn_t *) malloc(sizeof(newrelic_txn_t));
+    return web_transaction;
+}
+
+newrelic_segment_t *get_segment_pointer() {
+    if (segment != NULL) {
+        return segment;
+    }
+    segment = (newrelic_segment_t *) malloc(sizeof(newrelic_segment_t));
+    return segment;
+}
+
+newrelic_custom_event_t *get_custom_event() {
+    if (custom_event != NULL) {
+        return custom_event;
+    }
+
+    custom_event = (newrelic_custom_event_t *) malloc(sizeof(newrelic_custom_event_t));
+    return custom_event;
+}
+
+newrelic_external_segment_params_t *get_external_segment_params() {
+    if (external_segment_params != NULL) {
+        return external_segment_params;
+    }
+
+    external_segment_params = (newrelic_external_segment_params_t *) malloc(sizeof(newrelic_external_segment_params_t));
+    return external_segment_params;
+}
+
+newrelic_datastore_segment_params_t *get_datastore_segment_params() {
+    if (datastore_segment_params != NULL) {
+        return datastore_segment_params;
+    }
+
+    datastore_segment_params = (newrelic_datastore_segment_params_t *) malloc(sizeof(newrelic_datastore_segment_params_t));
+    return datastore_segment_params;
+}
+
+void _debug(const char *format, ...) {
+    if (internal_logfile && internal_loglevel == NEWRELIC_LOG_DEBUG ) {
+        va_list args;
+        va_start(args, format);
+        vfprintf(internal_logfile, format, args);
+        va_end(args);
+    }
+}
+
+bool newrelic_configure_log(const char *filename, newrelic_loglevel_t level)
+{
+    printf("DEBUG 'newrelic_configure_log' configuring log... %s[%d]\n", filename, level);
+
+    internal_filename = (char *) malloc(255);
+    strcpy(internal_filename, filename);
+
+    internal_logfile = fopen(internal_filename, "a+");
+    internal_loglevel = level;
+
+    _debug("DEBUG 'newrelic_configure_log' no errors | filename: %s, level: %d\n", filename, level);
+
+    return true;
+}
+
+bool newrelic_init(const char *daemon_socket, int time_limit_ms)
+{
+    if (time_limit_ms < 0)
+    {
+        _debug("DEBUG 'newrelic_init' invlid time_limit_ms - received < 0\n");
+        return false;
+    }
+
+    _debug("DEBUG 'newrelic_init' no errors | daemon_socket: %s, time_limit_ms: %d\n", daemon_socket, time_limit_ms);
+    return true;
+}
+
+newrelic_app_config_t *newrelic_create_app_config(const char *app_name, const char *license_key)
+{
+    if (app_name == NULL || strcmp(app_name, "") == 0) {
+        _debug("DEBUG 'newrelic_create_app_config' invalid app_name - received empty\n");
+        return NULL;
+    }
+
+    if (license_key == NULL || strcmp(license_key, "") == 0) {
+        _debug("DEBUG 'newrelic_create_app_config' invalid license_key - received empty\n");
+        return NULL;
+    }
+
+    _debug("DEBUG 'newrelic_create_app_config' no errors\n");
+    return get_app_config_pointer();
+}
+
+bool newrelic_destroy_app_config(newrelic_app_config_t **config)
+{
+    if (config == NULL) {
+        _debug("DEBUG 'newrelic_destroy_app_config' invalid config - received NULL\n");
+        return false;
+    }
+
+
+    _debug("DEBUG 'newrelic_destroy_app_config' no erros\n");
+    return true;
+}
+
+newrelic_app_t *newrelic_create_app(const newrelic_app_config_t *config, unsigned short timeout_ms){
+    if (config == NULL) {
+        _debug("DEBUG 'newrelic_create_app' invalid config - received NULL\n");
+    }
+
+    _debug("DEBUG 'newrelic_create_app' no errors | timeout_ms: %d\n", timeout_ms);
+    return get_app_pointer();
+}
+
+bool newrelic_destroy_app(newrelic_app_t **app) {
+    if (app == NULL || *app == NULL) {
+        _debug("DEBUG 'newrelic_destroy_app' invalid app - received NULL\n");
+        return false;
+    }
+    _debug("DEBUG 'newrelic_destroy_app' no errors\n");
+    return true;
+}
+
+newrelic_txn_t *newrelic_start_web_transaction(newrelic_app_t *app, const char *name)
+{
+    if (app == NULL) {
+        _debug("DEBUG 'newrelic_start_web_transaction' invalid app - received NULL\n");
+        return NULL;
+    }
+
+    if (name == NULL || strcmp(name, "") == 0) {
+        _debug("DEBUG 'newrelic_start_web_transaction' invalid name - received empty\n");
+        return NULL;
+    }
+
+    _debug("DEBUG 'newrelic_start_web_transaction' no errors | name: %s\n", name);
+    return get_transaction_pointer();
+}
+
+newrelic_txn_t *newrelic_start_non_web_transaction(newrelic_app_t *app, const char *name)
+{
+    if (app == NULL) {
+        _debug("DEBUG 'newrelic_start_non_web_transaction' invalid app - received NULL\n");
+        return NULL;
+    }
+
+    if (name == NULL || strcmp(name, "") == 0) {
+        _debug("DEBUG 'newrelic_start_non_web_transaction' invalid name - received empty\n");
+        return NULL;
+    }
+
+    _debug("DEBUG 'newrelic_start_non_web_transaction' no errors | name: %s\n", name);
+    return get_transaction_pointer();
+}
+
+bool newrelic_set_transaction_timing(newrelic_txn_t *transaction, newrelic_time_us_t start_time, newrelic_time_us_t duration) {
+    if (transaction == NULL) {
+        _debug("DEBUG 'newrelic_set_transaction_timing' invalid transaction - received NULL\n");
+        return false;
+    }
+
+    _debug("DEBUG 'newrelic_set_transaction_timing' no errors | start_time: %ld, duration: %ld\n", start_time, duration);
+    return true;
+}
+
+bool newrelic_end_transaction(newrelic_txn_t **transaction_ptr) {
+    if (transaction_ptr == NULL || *transaction_ptr == NULL) {
+        _debug("DEBUG 'newrelic_end_transaction' invalid transaction - received NULL\n");
+        return false;
+    }
+
+    _debug("DEBUG 'newrelic_end_transaction' no errors\n");
+    return true;
+}
+
+bool newrelic_add_attribute_int(newrelic_txn_t *transaction, const char *key, const int value) {
+    if (transaction == NULL) {
+        _debug("DEBUG 'newrelic_add_attribute_int' invalid transaction - received NULL\n");
+        return false;
+    }
+
+    if (key == NULL || strcmp(key, "") == 0) {
+        _debug("DEBUG 'newrelic_add_attribute_int' invalid key - received empty\n");
+        return false;
+    }
+
+    _debug("DEBUG 'newrelic_add_attribute_int' no erros | key: %s, value: %d\n", key, value);
+    return true;
+}
+
+bool newrelic_add_attribute_long(newrelic_txn_t *transaction, const char *key, const long value) {
+    if (transaction == NULL) {
+        _debug("DEBUG 'newrelic_add_attribute_long' invalid transaction - received NULL\n");
+        return false;
+    }
+
+    if (key == NULL || strcmp(key, "") == 0) {
+        _debug("DEBUG 'newrelic_add_attribute_long' invalid key - received empty\n");
+        return false;
+    }
+
+    _debug("DEBUG 'newrelic_add_attribute_long' no erros | key: %s, value: %ld\n", key, value);
+    return true;
+}
+bool newrelic_add_attribute_double(newrelic_txn_t *transaction, const char *key, const double value) {
+    if (transaction == NULL) {
+        _debug("DEBUG 'newrelic_add_attribute_double' invalid transaction - received NULL\n");
+        return false;
+    }
+
+    if (key == NULL || strcmp(key, "") == 0) {
+        _debug("DEBUG 'newrelic_add_attribute_double' invalid key - received empty\n");
+        return false;
+    }
+
+    _debug("DEBUG 'newrelic_add_attribute_double' no erros | key: %s, value: %f\n", key, value);
+    return true;
+}
+bool newrelic_add_attribute_string(newrelic_txn_t *transaction, const char *key, const char *value) {
+    if (transaction == NULL) {
+        _debug("DEBUG 'newrelic_add_attribute_string' invalid transaction - received NULL\n");
+        return false;
+    }
+
+    if (key == NULL || strcmp(key, "") == 0) {
+        _debug("DEBUG 'newrelic_add_attribute_string' invalid key - received empty\n");
+        return false;
+    }
+
+    if (value == NULL || strcmp(value, "") == 0) {
+        _debug("DEBUG 'newrelic_add_attribute_string' invalid value - received empty\n");
+        return false;
+    }
+
+    _debug("DEBUG 'newrelic_add_attribute_string' no erros | key: %s, value: %s\n", key, value);
+    return true;
+}
+void newrelic_notice_error(newrelic_txn_t *transaction, int priority, const char *errmsg, const char *errclass) {
+    if (transaction == NULL) {
+        _debug("DEBUG 'newrelic_notice_error' invalid transaction - received NULL\n");
+        return;
+    }
+
+    if (errmsg == NULL || strcmp(errmsg, "") == 0) {
+        _debug("DEBUG 'newrelic_notice_error' invalid errmsg - received empty\n");
+        return;
+    }
+
+    if (errclass == NULL || strcmp(errclass, "") == 0) {
+        _debug("DEBUG 'newrelic_notice_error' invalid errclass - received empty\n");
+        return;
+    }
+
+    _debug("DEBUG 'newrelic_notice_error' no errors | priority: %d, errmsg: %s, errclass: %s\n", priority, errmsg, errclass);
+    return;
+}
+
+newrelic_segment_t *newrelic_start_segment(newrelic_txn_t *transaction, const char *name, const char *category) {
+    if (transaction == NULL) {
+        _debug("DEBUG 'newrelic_start_segment' invalid transaction - received NULL\n");
+        return NULL;
+    }
+
+    if (name == NULL || strcmp(name, "") == 0) {
+        _debug("DEBUG 'newrelic_start_segment' invalid name - received empty, default='Unnamed Segment'\n");
+        return get_segment_pointer();
+    }
+
+    if (category == NULL || strcmp(category, "") == 0) {
+        _debug("DEBUG 'newrelic_start_segment' invalid category - received empty, default='Custom'\n");
+        return get_segment_pointer();
+    }
+
+    _debug("DEBUG 'newrelic_start_segment' no errors | name: %s, category: %s\n", name, category);
+    return get_segment_pointer();
+}
+newrelic_segment_t *newrelic_start_datastore_segment(newrelic_txn_t *transaction, const newrelic_datastore_segment_params_t *params) {
+    if (transaction == NULL) {
+        _debug("DEBUG 'newrelic_start_datastore_segment' invalid transaction - received NULL\n");
+        return NULL;
+    }
+
+    if (params == NULL) {
+        _debug("DEBUG 'newrelic_start_datastore_segment' invalid params - received NULL\n");
+        return NULL;
+    }
+
+    _debug("DEBUG 'newrelic_start_datastore_segment' no errors | product: %s, collection: %s, operation: %s, host: %s, port: %s, database_name: %s, query: %s\n", params->product, params->collection, params->operation, params->host, params->port_path_or_id, params->database_name, params->query);
+    return get_segment_pointer();
+}
+
+newrelic_segment_t *newrelic_start_external_segment(newrelic_txn_t *transaction, const newrelic_external_segment_params_t *params) {
+    if (transaction == NULL) {
+        _debug("DEBUG 'newrelic_start_external_segment' invalid transaction - received NULL\n");
+        return NULL;
+    }
+
+    if (params == NULL) {
+        _debug("DEBUG 'newrelic_start_external_segment' invalid params - received NULL\n");
+        return NULL;
+    }
+
+    _debug("DEBUG 'newrelic_start_external_segment' no errors | uri: %s, procedure: %s, library: %s\n", params->uri, params->procedure, params->library);
+    return get_segment_pointer();
+}
+bool newrelic_set_segment_parent(newrelic_segment_t *segment, newrelic_segment_t *parent) {
+    if (segment == NULL) {
+        _debug("DEBUG 'newrelic_set_segment_parent' invalid segment - received NULL\n");
+        return false;
+    }
+
+    if (parent == NULL) {
+        _debug("DEBUG 'newrelic_set_segment_parent' invalid parent - received NULL\n");
+        return false;
+    }
+
+    _debug("DEBUG 'newrelic_set_segment_parent' no errors\n");
+    return true;
+}
+
+bool newrelic_set_segment_parent_root(newrelic_segment_t *segment) {
+
+    if (segment == NULL) {
+        _debug("DEBUG 'newrelic_set_segment_parent_root' invalid segment - received NULL\n");
+        return false;
+    }
+
+    _debug("DEBUG 'newrelic_set_segment_parent_root' no errors\n");
+    return true;
+}
+
+bool newrelic_set_segment_timing(newrelic_segment_t *segment, newrelic_time_us_t start_time, newrelic_time_us_t duration) {
+    if (segment == NULL) {
+        _debug("DEBUG 'newrelic_set_segment_timing' invalid segment - received NULL\n");
+        return false;
+    }
+
+    _debug("DEBUG 'newrelic_set_segment_timing' no errors | start_time: %ld, duration: %d\n", start_time, duration);
+    return true;
+}
+
+bool newrelic_end_segment(newrelic_txn_t *transaction, newrelic_segment_t **segment_ptr) {
+    if (transaction == NULL) {
+        _debug("DEBUG 'newrelic_end_segment' invalid transaction - received NULL\n");
+        return false;
+    }
+
+    if (segment_ptr == NULL || *segment_ptr == NULL) {
+        _debug("DEBUG 'newrelic_end_segment' invalid segment - received NULL\n");
+        return false;
+    }
+
+    _debug("DEBUG 'newrelic_end_segment' no errors\n");
+    return true;
+}
+
+newrelic_custom_event_t *newrelic_create_custom_event(const char *event_type) {
+    if (strcmp(event_type, "") == 0) {
+        _debug("DEBUG 'newrelic_create_custom_event' invalid event_type - received empty\n");
+        return NULL;
+    }
+
+    _debug("DEBUG 'newrelic_create_custom_event' no errors | event_type: %s\n", event_type);
+    return get_custom_event();
+}
+void newrelic_discard_custom_event(newrelic_custom_event_t **event) {
+    if (event == NULL || *event == NULL) {
+        _debug("DEBUG 'newrelic_discard_custom_event' invalid event - received NULL\n");
+        return;
+    }
+
+    _debug("DEBUG 'newrelic_discard_custom_event' no errors\n");
+    return;
+}
+void newrelic_record_custom_event(newrelic_txn_t *transaction, newrelic_custom_event_t **event) {
+    if (transaction == NULL) {
+        _debug("DEBUG 'newrelic_record_custom_event' invalid transaction - received NULL\n");
+        return;
+    }
+
+    if (event == NULL || *event == NULL) {
+        _debug("DEBUG 'newrelic_record_custom_event' invalid event - received NULL\n");
+        return;
+    }
+
+    _debug("DEBUG 'newrelic_record_custom_event' no errors\n");
+    return;
+}
+bool newrelic_custom_event_add_attribute_int(newrelic_custom_event_t *event, const char *key, int value) {
+    if (event == NULL) {
+        _debug("DEBUG 'newrelic_custom_event_add_attribute_int' invalid event - received NULL\n");
+        return false;
+    }
+
+    if (strcmp(key, "") == 0) {
+        _debug("DEBUG 'newrelic_custom_event_add_attribute_int' invalid key - received empty\n");
+        return false;
+    }
+
+    _debug("DEBUG 'newrelic_custom_event_add_attribute_int' no errors | key: %s, value: %d\n", key, value);
+    return true;
+}
+bool newrelic_custom_event_add_attribute_long(newrelic_custom_event_t *event, const char *key, long value) {
+    if (event == NULL) {
+        _debug("DEBUG 'newrelic_custom_event_add_attribute_long' invalid event - received NULL\n");
+        return false;
+    }
+
+    if (strcmp(key, "") == 0) {
+        _debug("DEBUG 'newrelic_custom_event_add_attribute_long' invalid key - received empty\n");
+        return false;
+    }
+
+    _debug("DEBUG 'newrelic_custom_event_add_attribute_long' no errors | key: %s, value: %ld\n", key, value);
+    return true;
+}
+bool newrelic_custom_event_add_attribute_double(newrelic_custom_event_t *event, const char *key, double value)
+{
+    if (event == NULL) {
+        _debug("DEBUG 'newrelic_custom_event_add_attribute_double' invalid event - received NULL\n");
+        return false;
+    }
+
+    if (strcmp(key, "") == 0) {
+        _debug("DEBUG 'newrelic_custom_event_add_attribute_double' invalid key - received empty\n");
+        return false;
+    }
+
+    _debug("DEBUG 'newrelic_custom_event_add_attribute_double' no errors | key: %s, value: %f\n", key, value);
+    return true;
+}
+
+bool newrelic_custom_event_add_attribute_string(newrelic_custom_event_t *event, const char *key, const char *value) {
+    if (event == NULL) {
+        _debug("DEBUG 'newrelic_custom_event_add_attribute_string' invalid event - received NULL\n");
+        return false;
+    }
+
+    if (strcmp(key, "") == 0) {
+        _debug("DEBUG 'newrelic_custom_event_add_attribute_string' invalid key - received empty\n");
+        return false;
+    }
+
+    if (strcmp(value, "") == 0) {
+        _debug("DEBUG 'newrelic_custom_event_add_attribute_string' invalid value - received empty\n");
+        return false;
+    }
+
+    _debug("DEBUG 'newrelic_custom_event_add_attribute_string' no errors | key: %s, value: %s\n", key, value);
+    return true;
+}
+
+const char *newrelic_version(void) {
+    _debug("DEBUG 'newrelic_version' no errors");
+    return "1.3.0";
+}
+
+bool newrelic_record_custom_metric(newrelic_txn_t *transaction, const char *metric_name, double milliseconds) {
+
+    if (transaction == NULL) {
+        _debug("DEBUG 'newrelic_record_custom_metric' invalid transaction - received NULL\n");
+        return false;
+    }
+
+    if (strcmp(metric_name, "") == 0) {
+        _debug("DEBUG 'newrelic_record_custom_metric' invalid metric_name - received empty\n");
+        return false;
+    }
+
+    if (milliseconds < 0) {
+        _debug("DEBUG 'newrelic_record_custom_metric' invalid milliseconds - received < 0\n");
+        return false;
+    }
+
+    _debug("DEBUG 'newrelic_record_custom_metric' no errors | metric_name: %s, milliseconds: %f\n", metric_name, milliseconds);
+    return true;
+}
+
+bool newrelic_ignore_transaction(newrelic_txn_t *transaction) {
+    if (transaction == NULL) {
+        _debug("DEBUG 'newrelic_ignore_transaction' invalid transaction - received NULL\n");
+        return false;
+    }
+    _debug("DEBUG 'newrelic_ignore_transaction' no errors\n");
+    return true;
+}
+
+char *newrelic_create_distributed_trace_payload(newrelic_txn_t *transaction, newrelic_segment_t *segment) {
+    char *value;
+
+    value = (char *) malloc(sizeof(char));
+    strcpy(value, "r");
+
+    if (transaction == NULL) {
+        _debug("DEBUG 'newrelic_create_distributed_trace_payload' invalid transaction - received NULL\n");
+        return value;
+    }
+
+    if (segment == NULL) {
+        _debug("DEBUG 'newrelic_create_distributed_trace_payload' invalid segment - received NULL\n");
+        return value;
+    }
+
+    _debug("DEBUG 'newrelic_create_distributed_trace_payload' no errors\n");
+
+    return value;
+}
+
+bool newrelic_accept_distributed_trace_payload(newrelic_txn_t *transaction, const char *payload, const char *transport_type) {
+    if (transaction == NULL) {
+        _debug("DEBUG 'newrelic_accept_distributed_trace_payload' invalid transaction - received NULL\n");
+        return false;
+    }
+
+    if (strcmp(payload, "") == 0) {
+        _debug("DEBUG 'newrelic_accept_distributed_trace_payload' invalid payload - received empty\n");
+        return false;
+    }
+
+    if (strcmp(transport_type, "") == 0) {
+        _debug("DEBUG 'newrelic_accept_distributed_trace_payload' invalid transport_type - received empty\n");
+        return false;
+    }
+
+    _debug("DEBUG 'newrelic_accept_distributed_trace_payload' no errors | payload: %s, transport_type: %s\n", payload, transport_type);
+    return true;
+}
+
+char *newrelic_create_distributed_trace_payload_httpsafe(newrelic_txn_t *transaction, newrelic_segment_t *segment) {
+    char *value;
+
+
+    value = (char *) malloc(sizeof(char));
+    strcpy(value, "r");
+
+    if (transaction == NULL) {
+        _debug("DEBUG 'newrelic_create_distributed_trace_payload_httpsafe' invalid transaction - received NULL\n");
+        return value;
+    }
+
+    if (segment == NULL) {
+        _debug("DEBUG 'newrelic_create_distributed_trace_payload_httpsafe' invalid segment - received NULL\n");
+        return value;
+    }
+
+    _debug("DEBUG 'newrelic_create_distributed_trace_payload_httpsafe' no errors\n");
+
+    return value;
+}
+
+bool newrelic_accept_distributed_trace_payload_httpsafe(newrelic_txn_t *transaction, const char *payload, const char *transport_type) {
+    if (transaction == NULL) {
+        _debug("DEBUG 'newrelic_accept_distributed_trace_payload_httpsafe' invalid transaction - received NULL\n");
+        return false;
+    }
+
+    if (strcmp(payload, "") == 0) {
+        _debug("DEBUG 'newrelic_accept_distributed_trace_payload_httpsafe' invalid payload - received empty\n");
+        return false;
+    }
+
+    if (strcmp(transport_type, "") == 0) {
+        _debug("DEBUG 'newrelic_accept_distributed_trace_payload_httpsafe' invalid transport_type - received empty\n");
+        return false;
+    }
+
+    _debug("DEBUG 'newrelic_accept_distributed_trace_payload_httpsafe' no errors | payload: %s, transport_type: %s\n", payload, transport_type);
+    return true;
+}
+
+bool newrelic_set_transaction_name(newrelic_txn_t *transaction, const char *transaction_name) {
+    if (transaction == NULL) {
+        _debug("DEBUG 'newrelic_set_transaction_name' invalid transaction - received NULL\n");
+        return false;
+    }
+    if (strcmp(transaction_name, "") == 0) {
+        _debug("DEBUG 'newrelic_set_transaction_name' invalid transaction name - received empty\n");
+        return false;
+    }
+
+    _debug("DEBUG 'newrelic_set_transaction_name' no errors | name: %s\n", transaction_name);
+
+    return true;
+}
+


### PR DESCRIPTION
It was added a new `libnewrelic.so` which simulates the original library. In this way, we can make some basic tests around the basic functionality of the integration.

This makes a sanity check to verify if everything is well written.